### PR TITLE
Implement a configuration file for customizable mounting

### DIFF
--- a/driver/exports.yml
+++ b/driver/exports.yml
@@ -10,6 +10,6 @@ VitaShellKernel:
     VitaShellKernelLibrary:
       syscall: true
       functions:
-        - shellKernelIsUx0Redirected
-        - shellKernelRedirectUx0
-        - shellKernelUnredirectUx0
+        - shellKernelIsRedirected
+        - shellKernelRedirect
+        - shellKernelUnredirect

--- a/driver/main.c
+++ b/driver/main.c
@@ -202,7 +202,6 @@ int redirect_ux0() {
 
 	if (mount_cfg.microsd_mnt > 0 && mount_cfg.microsd_dev != NULL) {
 		shellKernelRedirect(mount_cfg.microsd_mnt, mount_cfg.microsd_dev);
-		io_remount(MOUNT_POINT_UX0);
 		if (mount_cfg.microsd_mnt == MOUNT_POINT_UMA0)
 			io_mount(mount_cfg.microsd_mnt);
 		else

--- a/driver/main.c
+++ b/driver/main.c
@@ -142,23 +142,21 @@ static void load_mount_cfg() {
 	}
 }
 
-// TODO: Make this more generic
-int shellKernelIsUx0Redirected() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UX0);
+int shellKernelIsRedirected(int mountpoint, SceIoDevice *device) {
+	SceIoMountPoint *mount = sceIoFindMountPoint(mountpoint);
 	if (!mount) {
 		return -1;
 	}
 
-	if (mount->dev == &uma_ux0_dev_sdcard && mount->dev2 == &uma_ux0_dev_sdcard) {
+	if (mount->dev == device && mount->dev2 == device) {
 		return 1;
 	}
 
 	return 0;
 }
 
-// TODO: Make this more generic
-int shellKernelUnredirectUx0() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UX0);
+int shellKernelUnredirect(int mountpoint) {
+	SceIoMountPoint *mount = sceIoFindMountPoint(mountpoint);
 	if (!mount) {
 		return -1;
 	}
@@ -170,24 +168,6 @@ int shellKernelUnredirectUx0() {
 		ori_dev = NULL;
 		ori_dev2 = NULL;
 	}
-
-	return 0;
-}
-
-// TODO: Make this more generic
-int shellKernelRedirectUx0() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UX0);
-	if (!mount) {
-		return -1;
-	}
-
-	if (mount->dev != &uma_ux0_dev_sdcard && mount->dev2 != &uma_ux0_dev_sdcard) {
-		ori_dev = mount->dev;
-		ori_dev2 = mount->dev2;
-	}
-
-	mount->dev = &uma_ux0_dev_sdcard;
-	mount->dev2 = &uma_ux0_dev_sdcard;
 
 	return 0;
 }

--- a/driver/main.c
+++ b/driver/main.c
@@ -26,9 +26,8 @@
 
 #include <taihen.h>
 
-#define MOUNT_POINT_ID 0x800
-
-#define MOUNT_POINT_ID2 0xF00 //used uma0 ID
+#define MOUNT_POINT_UX0 0x800
+#define MOUNT_POINT_UMA0 0xF00 //used uma0 ID
 
 int module_get_offset(SceUID pid, SceUID modid, int segidx, size_t offset, uintptr_t *addr);
 
@@ -57,9 +56,9 @@ typedef struct {
 	int unk7;
 } SceIoMountPoint;
 
-static SceIoDevice uma_ux0_dev = { "ux0:", "exfatux0", "sdstor0:gcd-lp-ign-entire", "sdstor0:gcd-lp-ign-entire", MOUNT_POINT_ID };
+static SceIoDevice uma_ux0_dev = { "ux0:", "exfatux0", "sdstor0:gcd-lp-ign-entire", "sdstor0:gcd-lp-ign-entire", MOUNT_POINT_UX0 };
 
-static SceIoDevice uma_uma0_dev = { "uma0:", "exfatuma0", "sdstor0:xmc-lp-ign-userext", "sdstor0:xmc-lp-ign-userext", MOUNT_POINT_ID2 }; //For Vita MU
+static SceIoDevice uma_uma0_dev = { "uma0:", "exfatuma0", "sdstor0:xmc-lp-ign-userext", "sdstor0:xmc-lp-ign-userext", MOUNT_POINT_UMA0 }; //For Vita MU
 
 static SceIoMountPoint *(* sceIoFindMountPoint)(int id) = NULL;
 
@@ -83,10 +82,8 @@ static void io_mount(int id) {
 	ksceIoMount(id, NULL, 0, 0, 0, 0);
 }
 
-////{Region Scraps
-
 int shellKernelIsUx0Redirected() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID);
+	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UX0);
 	if (!mount) {
 		return -1;
 	}
@@ -99,7 +96,7 @@ int shellKernelIsUx0Redirected() {
 }
 
 int shellKernelUnredirectUx0() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID);
+	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UX0);
 	if (!mount) {
 		return -1;
 	}
@@ -115,10 +112,8 @@ int shellKernelUnredirectUx0() {
 	return 0;
 }
 
-////}
-
 int shellKernelRedirectUx0() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID);
+	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UX0);
 	if (!mount) {
 		return -1;
 	}
@@ -135,7 +130,7 @@ int shellKernelRedirectUx0() {
 }
 
 int shellKernelRedirectUma0() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID2);
+	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_UMA0);
 	if (!mount) {
 		return -1;
 	}
@@ -163,9 +158,9 @@ int redirect_ux0() {
 	module_get_offset(KERNEL_PID, info.modid, 0, 0x138C1, (uintptr_t *)&sceIoFindMountPoint);
 
 	shellKernelRedirectUx0();
-	io_remount(MOUNT_POINT_ID);
+	io_remount(MOUNT_POINT_UX0);
 	shellKernelRedirectUma0(); //Added uma0 mount was ux0 ie Vita MU
-	io_mount(MOUNT_POINT_ID2); //No need to remount since it's not mounted!
+	io_mount(MOUNT_POINT_UMA0); //No need to remount since it's not mounted!
 
 	return 0;
 }

--- a/driver/main.c
+++ b/driver/main.c
@@ -28,6 +28,8 @@
 
 #define MOUNT_POINT_ID 0x800
 
+#define MOUNT_POINT_ID2 0xF00 //used uma0 ID
+
 int module_get_offset(SceUID pid, SceUID modid, int segidx, size_t offset, uintptr_t *addr);
 
 typedef struct {
@@ -57,6 +59,8 @@ typedef struct {
 
 static SceIoDevice uma_ux0_dev = { "ux0:", "exfatux0", "sdstor0:gcd-lp-ign-entire", "sdstor0:gcd-lp-ign-entire", MOUNT_POINT_ID };
 
+static SceIoDevice uma_uma0_dev = { "uma0:", "exfatuma0", "sdstor0:xmc-lp-ign-userext", "sdstor0:xmc-lp-ign-userext", MOUNT_POINT_ID2 }; //For Vita MU
+
 static SceIoMountPoint *(* sceIoFindMountPoint)(int id) = NULL;
 
 static SceIoDevice *ori_dev = NULL, *ori_dev2 = NULL;
@@ -75,6 +79,12 @@ static void io_remount(int id) {
 	ksceIoMount(id, NULL, 0, 0, 0, 0);
 }
 
+static void io_mount(int id) {
+	ksceIoMount(id, NULL, 0, 0, 0, 0);
+}
+
+////{Region Scraps
+
 int shellKernelIsUx0Redirected() {
 	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID);
 	if (!mount) {
@@ -84,23 +94,6 @@ int shellKernelIsUx0Redirected() {
 	if (mount->dev == &uma_ux0_dev && mount->dev2 == &uma_ux0_dev) {
 		return 1;
 	}
-
-	return 0;
-}
-
-int shellKernelRedirectUx0() {
-	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID);
-	if (!mount) {
-		return -1;
-	}
-
-	if (mount->dev != &uma_ux0_dev && mount->dev2 != &uma_ux0_dev) {
-		ori_dev = mount->dev;
-		ori_dev2 = mount->dev2;
-	}
-
-	mount->dev = &uma_ux0_dev;
-	mount->dev2 = &uma_ux0_dev;
 
 	return 0;
 }
@@ -122,6 +115,42 @@ int shellKernelUnredirectUx0() {
 	return 0;
 }
 
+////}
+
+int shellKernelRedirectUx0() {
+	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID);
+	if (!mount) {
+		return -1;
+	}
+
+	if (mount->dev != &uma_ux0_dev && mount->dev2 != &uma_ux0_dev) {
+		ori_dev = mount->dev;
+		ori_dev2 = mount->dev2;
+	}
+
+	mount->dev = &uma_ux0_dev;
+	mount->dev2 = &uma_ux0_dev;
+
+	return 0;
+}
+
+int shellKernelRedirectUma0() {
+	SceIoMountPoint *mount = sceIoFindMountPoint(MOUNT_POINT_ID2);
+	if (!mount) {
+		return -1;
+	}
+
+	if (mount->dev != &uma_uma0_dev && mount->dev2 != &uma_uma0_dev) {
+		ori_dev = mount->dev;
+		ori_dev2 = mount->dev2;
+	}
+
+	mount->dev = &uma_uma0_dev;
+	mount->dev2 = &uma_uma0_dev;
+
+	return 0;
+}
+
 // ux0 redirect by theflow
 int redirect_ux0() {
 	// Get tai module info
@@ -135,6 +164,8 @@ int redirect_ux0() {
 
 	shellKernelRedirectUx0();
 	io_remount(MOUNT_POINT_ID);
+	shellKernelRedirectUma0(); //Added uma0 mount was ux0 ie Vita MU
+	io_mount(MOUNT_POINT_ID2); //No need to remount since it's not mounted!
 
 	return 0;
 }


### PR DESCRIPTION
Implemented the suggestion from here: https://github.com/xyzz/gamecard-microsd/pull/10#issuecomment-321158376

And as specified, the default configuration (when the config file is not deployed or if there was an error parsing it), is for the SDCard to be mounted to ux0 and the memory card not to be mounted at all.

The path for the configuration file is hardcoded to `ur0:tai/gamesd.cfg` and the format for the config file is the following:

```
microsd=ux0
memorycard=uma0
```