### PR TITLE
added appmgr patch two allow memory card remount

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -226,7 +226,7 @@ void patch_appmgr() {
 void _start() __attribute__ ((weak, alias("module_start")));
 int module_start(SceSize args, void *argp) {
 	patch_sdstor();
-  patch_appmgr();
+	patch_appmgr();
 	poke_gamecard();
 	register_sysevent();
 	redirect_ux0();


### PR DESCRIPTION
This plugin used to freeze if loaded without enso due to a filepath check in appmgr.